### PR TITLE
TaskBuilder: support awaiting non-generic Task and add CE helpers

### DIFF
--- a/.idea/.idea.DataParser/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/.idea.DataParser/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/DataParser.Console/DataFileParseResult.fs
+++ b/DataParser.Console/DataFileParseResult.fs
@@ -3,5 +3,6 @@
 open DataParser.Console.DataFiles
 
 type DataFileParseResult =
-    { DataFileName : DataFileName
+    { DataFilePath : FilePath
+      DataFileName : DataFileName
       JsonElements : seq<JsonObject> }

--- a/DataParser.Console/DataParser.Console.fsproj
+++ b/DataParser.Console/DataParser.Console.fsproj
@@ -9,6 +9,7 @@
     <ItemGroup>
         <Compile Include="TaskBuilder.fs" />
         <Compile Include="Task.fs" />
+        <Compile Include="Map.fs" />
         <Compile Include="Result.fs" />
         <Compile Include="ResultBuilder.fs" />
         <Compile Include="ResultMap.fs" />

--- a/DataParser.Console/FileRead.fs
+++ b/DataParser.Console/FileRead.fs
@@ -30,7 +30,10 @@ let parseDataFile dataFile =
         return result {
             let! parsedJsonObjects =
                 Result.traverseSeq (parseDataFileLine dataFile.FormatLines) dataFileLines
-            return { DataFileName = dataFile.Name; JsonElements = parsedJsonObjects }
+            return { 
+                DataFilePath = dataFile.FilePath
+                DataFileName = dataFile.Name
+                JsonElements = parsedJsonObjects }
         }
     }
     

--- a/DataParser.Console/Map.fs
+++ b/DataParser.Console/Map.fs
@@ -1,0 +1,9 @@
+module Map
+
+open System.Threading.Tasks
+
+let traverseTask (f: 'b -> Task<'c>) =
+    Map.fold (fun acc k v -> task { 
+        let! t = f v 
+        and! acc' = acc  
+        return Map.add k t acc' }) (task { return Map.empty })

--- a/DataParser.Console/Program.fs
+++ b/DataParser.Console/Program.fs
@@ -17,22 +17,47 @@ let okHandler _ = writeOutputFile OutputFolderPath
 let errorHandler filePath errors =
     eprintfn $"Error occurred during processing data file: {filePath}. Errors are : %+A{errors}"
 
+let consolidateResults (ResultMap dataFileFormats) =
+    let folder acc k v =
+        match v with
+        | Ok dataFileFormat ->
+            task {
+                let! parseResult = parseDataFile dataFileFormat
+                match parseResult with
+                | Ok result ->
+                    return! Task.liftA3 Map.add (Task.singleton k) (Task.singleton (Ok result)) acc
+                | Error e ->
+                    return! Task.liftA3 Map.add (Task.singleton k) (Task.singleton (Error e)) acc
+            }
+        | Error e -> 
+            task {
+                return! Task.liftA3 Map.add (Task.singleton k) (Task.singleton (Error e)) acc
+            }
+    
+    Map.fold folder (Task.singleton Map.empty) dataFileFormats
+    |> Task.map ResultMap
+
 printfn "Reading spec files..."
 
-task {
-    let! specs = readAllSpecFiles SpecFolderPath
+let t =
+    task {
+        let! specs = readAllSpecFiles SpecFolderPath
 
-    let dataFileInfos = getDataFileInfos DataFolderPath
+        let dataFileInfos = getDataFileInfos DataFolderPath
 
-    printfn "Parsing data files..."
-    let parsedDateFileFormats = getDataFileFormats specs dataFileInfos
-        
-    let dataFileParsedResults =
-        ResultMap.bindResult parseDataFile parsedDateFileFormats
+        printfn "Parsing data files..."
+        let dataFileFormats = getDataFileFormats specs dataFileInfos
 
-    printfn "Writing to output folder..."
-    ResultMap.biIter okHandler errorHandler dataFileParsedResults
+        //let dataFileParsedResults = ResultMap.map parseDataFile dataFileFormats
+        //let! dataFileParsedResults = ResultMap.traverseTask parseDataFile dataFileFormats
 
-    printfn "Processing complete. Press Enter to exit."
-    ignore <| Console.ReadLine()
-} |> ignore
+        let! consolidatedResults = consolidateResults dataFileFormats
+
+        printfn "Writing to output folder..."
+        ResultMap.biIter okHandler errorHandler consolidatedResults
+
+        printfn "Processing complete. Press Enter to exit."
+        ignore <| Console.ReadLine()
+    }
+
+t.GetAwaiter().GetResult() 

--- a/DataParser.Console/ResultMap.fs
+++ b/DataParser.Console/ResultMap.fs
@@ -1,5 +1,7 @@
 ﻿namespace ResultMap
 
+open System.Threading.Tasks
+
 type ResultMap<'TKey, 'TOkValue, 'TErrorValue when 'TKey : comparison> =
     | ResultMap of Map<'TKey, Result<'TOkValue, 'TErrorValue list>>
    
@@ -9,12 +11,29 @@ type ResultMap<'TKey, 'TOkValue, 'TErrorValue when 'TKey : comparison> =
         
 module ResultMap =
 
+    let empty = ResultMap Map.empty
+
     let unResultMap (ResultMap m) = m
 
     let map f =
         ResultMap
         << Map.map (fun _ -> Result.map f)
         << unResultMap
+
+    let traverseTask f (ResultMap m) = 
+        let folder acc k v = task {
+            let! acc' = acc
+            match v with
+            | Ok x -> 
+                let! t = f x
+                return Map.add k (Ok t) acc'
+            | Error e -> 
+                return Map.add k (Error e) acc'
+
+        }
+    
+        Map.fold folder (task { return Map.empty }) m
+        |> Task.map ResultMap
             
     let bindResult f =
         ResultMap

--- a/DataParser.Console/Task.fs
+++ b/DataParser.Console/Task.fs
@@ -8,16 +8,24 @@ let map f x = task {
     return f result
 }
 
+let bind f x = task {
+    let! result = x
+    return! f result
+}
+
+let toUnit (x: Task) = task {
+    do! x
+    return ()
+}
+
 let (<!>) = map
 
 let (<*>) (f: Task<'a -> 'b>) (x: Task<'a>) = task {
-    let! _ = Task.WhenAll(f, x) :?> Task<unit>
+    let tasks = [|f :> Task; x :> Task|]
+    let! _ = Task.WhenAll(tasks)
     return f.Result x.Result
 }
 
-let liftA2 f x y = f <!> x <*> y
+let liftA3 f x y z = f <!> x <*> y <*> z
 
-let traverseSeq f xs = 
-    let cons x xs = x :: xs
-    let (<%>) = liftA2 cons
-    Seq.fold (fun acc x -> f x <%> acc) (task { return [] }) xs
+let singleton x = task { return x }

--- a/DataParser.Console/data/fileformat_2020-10-15.txt
+++ b/DataParser.Console/data/fileformat_2020-10-15.txt
@@ -1,3 +1,3 @@
-﻿Diabetes  1  1
-Asthma    0-14
+﻿Diabetes 1  1
+Asthma   0-14
 Stroke    1122

--- a/DataParser.Console/specs/fileformat2.csv
+++ b/DataParser.Console/specs/fileformat2.csv
@@ -1,4 +1,4 @@
-﻿width,"column name",datatype
+﻿width,"column nme",datatype
 10,name,TEXT
 1,valid,BOOLEAN
 3,count,INTEGER

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,0 +1,29 @@
+﻿#-------------------------------------------------------------------------------#
+#               Qodana analysis is configured by qodana.yaml file               #
+#             https://www.jetbrains.com/help/qodana/qodana-yaml.html            #
+#-------------------------------------------------------------------------------#
+version: "1.0"
+
+#Specify IDE code to run analysis without container (Applied in CI/CD pipeline)
+ide: QDNET
+
+#Specify inspection profile for code analysis
+profile:
+  name: qodana.starter
+
+#Enable inspections
+#include:
+#  - name: <SomeEnabledInspectionId>
+
+#Disable inspections
+#exclude:
+#  - name: <SomeDisabledInspectionId>
+#    paths:
+#      - <path/where/not/run/inspection>
+
+#Execute shell command before Qodana execution (Applied in CI/CD pipeline)
+#bootstrap: sh ./prepare-qodana.sh
+
+#Install IDE plugins before Qodana execution (Applied in CI/CD pipeline)
+#plugins:
+#  - id: <plugin.id> #(plugin id can be found at https://plugins.jetbrains.com)


### PR DESCRIPTION
Adds a Bind overload to await non-generic Task, plus Return/ReturnFrom/Zero helpers and a safer MergeSources implementation so the local task CE can await Task and support let! x and y = .... Builds and runs locally.