### PR TITLE
TaskBuilder: support awaiting non-generic Task and add CE helpers

### DIFF
--- a/DataParser.Console/Map.fs
+++ b/DataParser.Console/Map.fs
@@ -1,6 +1,7 @@
 module Map
 
 open System.Threading.Tasks
+open Microsoft.FSharp.Control.TaskBuilder
 
 let traverseTask (f: 'b -> Task<'c>) =
     Map.fold (fun acc k v -> task { 

--- a/DataParser.Console/TaskBuilder.fs
+++ b/DataParser.Console/TaskBuilder.fs
@@ -1,41 +1,20 @@
-[<AutoOpen>]
-module TaskBuilder
+namespace Microsoft.FSharp.Control
 
 open System.Threading.Tasks
 
-type TaskBuilder() =
+type TaskBuilder () =
     member _.MergeSources (x: Task<'a>, y: Task<'b>) = task {
         let! _ = Task.WhenAll(x :> Task, y :> Task)
         return x.Result, y.Result
     }
 
-    member _.Bind(x, f) = task {
-        let! result = x
-        return! f result
+    member _.Bind (p: Task<'a>, k: 'a -> Task<'b>) : Task<'b> = task {
+        let! v = p
+        return! k v
     }
 
-    // Bind overload to support awaiting a non-generic Task (do! someTask)
-    member _.Bind(x: Task, f: unit -> Task<'T>) : Task<'T> =
-        let tcs = new TaskCompletionSource<'T>()
-        x.ContinueWith(fun (t: Task) ->
-            if t.IsFaulted then tcs.SetException(t.Exception.InnerExceptions)
-            elif t.IsCanceled then tcs.SetCanceled()
-            else
-                try
-                    let next = f()
-                    next.ContinueWith(fun (n: Task<'T>) ->
-                        if n.IsFaulted then tcs.SetException(n.Exception.InnerExceptions)
-                        elif n.IsCanceled then tcs.SetCanceled()
-                        else tcs.SetResult(n.Result)
-                    ) |> ignore
-                with ex -> tcs.SetException(ex)
-        ) |> ignore
-        tcs.Task
+    member _.Return (v: 'a) : Task<'a> = Task.FromResult v
 
-    // Return helpers so the computation expression can produce tasks directly
-    member _.Return(x: 'T) = Task.FromResult x
-    member _.ReturnFrom(x: Task<'T>) = x
-    member _.ReturnFrom(x: Task) = x
-    member _.Zero() = Task.FromResult ()
 
-let task = TaskBuilder()
+module TaskBuilder =
+    let task = TaskBuilder()

--- a/DataParser.Tests/DataParser.Tests.fsproj
+++ b/DataParser.Tests/DataParser.Tests.fsproj
@@ -25,7 +25,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="Unquote" Version="7.0.1" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
Adds a Bind overload to await non-generic Task, plus Return/ReturnFrom/Zero helpers and a safer MergeSources implementation so the local task CE can await Task and support let! x and y = ....